### PR TITLE
Fixes typo in method name

### DIFF
--- a/src/static/patterns/behavioral_observer.js
+++ b/src/static/patterns/behavioral_observer.js
@@ -40,13 +40,13 @@ var fees = {
   }
 };
 
-var proft = {
+var profit = {
   update: function(product) {
     product.price = product.price * 2;
   }
 };
 
-module.exports = [Product, fees, proft];`,
+module.exports = [Product, fees, profit];`,
   codeES6: `class Product {
   constructor() {
     this.price = 0;

--- a/src/static/patterns/behavioral_observer.js
+++ b/src/static/patterns/behavioral_observer.js
@@ -83,13 +83,13 @@ class fees {
   }
 }
 
-class proft {
+class profit {
   update(product) {
     product.price = product.price * 2;
   }
 }
 
-export { Product, fees, proft };`
+export { Product, fees, profit };`
 };
 
 export default OBSERVER;


### PR DESCRIPTION
I guess this should be 'profit'. Is there other places I should change this?